### PR TITLE
Update jupyter-server-proxy fork version

### DIFF
--- a/Manifest.toml
+++ b/Manifest.toml
@@ -1,20 +1,18 @@
 # This file is machine-generated - editing it directly is not advised
 
-julia_version = "1.11.1"
+julia_version = "1.10.5"
 manifest_format = "2.0"
-project_hash = "d702d32f28890928c3b0a69b7dbbb9aa1de15960"
+project_hash = "b001cb6898b7e2087c56d38463ba1c572909987c"
 
 [[deps.ArgTools]]
 uuid = "0dad84c5-d112-42e6-8d28-ef12dabb789f"
-version = "1.1.2"
+version = "1.1.1"
 
 [[deps.Artifacts]]
 uuid = "56f22d72-fd6d-98f1-02f0-08ddc0907c33"
-version = "1.11.0"
 
 [[deps.Base64]]
 uuid = "2a0f44e3-6c83-55bd-87e4-b1978d98bd5f"
-version = "1.11.0"
 
 [[deps.BitFlags]]
 git-tree-sha1 = "0691e34b3bb8be9307330f88d1a3c3f25466c24d"
@@ -52,12 +50,10 @@ version = "1.0.0"
 [[deps.Dates]]
 deps = ["Printf"]
 uuid = "ade2ca70-3891-5945-98fb-dc099432e06a"
-version = "1.11.0"
 
 [[deps.Distributed]]
 deps = ["Random", "Serialization", "Sockets"]
 uuid = "8ba89e20-285c-5b6f-9357-94700520ee1b"
-version = "1.11.0"
 
 [[deps.Downloads]]
 deps = ["ArgTools", "FileWatching", "LibCURL", "NetworkOptions"]
@@ -82,7 +78,6 @@ version = "0.10.13"
 
 [[deps.FileWatching]]
 uuid = "7b1f6079-737a-58dc-b8bc-7a2ca5c1b5ee"
-version = "1.11.0"
 
 [[deps.FuzzyCompletions]]
 deps = ["REPL"]
@@ -105,7 +100,6 @@ version = "0.9.5"
 [[deps.InteractiveUtils]]
 deps = ["Markdown"]
 uuid = "b77e0a4c-d291-57a0-90e8-8db25a27a240"
-version = "1.11.0"
 
 [[deps.IteratorInterfaceExtensions]]
 git-tree-sha1 = "a3f24677c21f5bbe9d2a714f95dcd58337fb2856"
@@ -131,17 +125,16 @@ version = "0.6.4"
 [[deps.LibCURL_jll]]
 deps = ["Artifacts", "LibSSH2_jll", "Libdl", "MbedTLS_jll", "Zlib_jll", "nghttp2_jll"]
 uuid = "deac9b47-8bc7-5906-a0fe-35ac56dc84c0"
-version = "8.6.0+0"
+version = "8.4.0+0"
 
 [[deps.LibGit2]]
 deps = ["Base64", "LibGit2_jll", "NetworkOptions", "Printf", "SHA"]
 uuid = "76f85450-5226-5b5a-8eaa-529ad045b433"
-version = "1.11.0"
 
 [[deps.LibGit2_jll]]
 deps = ["Artifacts", "LibSSH2_jll", "Libdl", "MbedTLS_jll"]
 uuid = "e37daf67-58a4-590a-8e99-b0245dd2ffc5"
-version = "1.7.2+0"
+version = "1.6.4+0"
 
 [[deps.LibSSH2_jll]]
 deps = ["Artifacts", "Libdl", "MbedTLS_jll"]
@@ -150,17 +143,15 @@ version = "1.11.0+1"
 
 [[deps.Libdl]]
 uuid = "8f399da3-3557-5675-b5ff-fb832c97cbdb"
-version = "1.11.0"
 
 [[deps.Logging]]
 uuid = "56ddb016-857b-54e1-b83d-db4d58db5568"
-version = "1.11.0"
 
 [[deps.LoggingExtras]]
 deps = ["Dates", "Logging"]
-git-tree-sha1 = "c1dd6d7978c12545b4179fb6153b9250c96b0075"
+git-tree-sha1 = "f02b56007b064fbfddb4c9cd60161b6dd0f40df3"
 uuid = "e6f89c97-d47a-5376-807f-9c37f3926c36"
-version = "1.0.3"
+version = "1.1.0"
 
 [[deps.MIMEs]]
 git-tree-sha1 = "65f28ad4b594aebe22157d6fac869786a255b7eb"
@@ -176,7 +167,6 @@ version = "1.1.2"
 [[deps.Markdown]]
 deps = ["Base64"]
 uuid = "d6f4376e-aef5-505a-96c1-9c027394607a"
-version = "1.11.0"
 
 [[deps.MbedTLS]]
 deps = ["Dates", "MbedTLS_jll", "MozillaCACerts_jll", "NetworkOptions", "Random", "Sockets"]
@@ -187,11 +177,11 @@ version = "1.1.9"
 [[deps.MbedTLS_jll]]
 deps = ["Artifacts", "Libdl"]
 uuid = "c8ffd9c3-330d-5841-b78e-0817d7145fa1"
-version = "2.28.6+0"
+version = "2.28.2+1"
 
 [[deps.MozillaCACerts_jll]]
 uuid = "14a3606d-f60d-562e-9121-12d972cd8159"
-version = "2023.12.12"
+version = "2023.1.10"
 
 [[deps.MsgPack]]
 deps = ["Serialization"]
@@ -221,13 +211,9 @@ uuid = "bac558e1-5e72-5ebc-8fee-abe8a469f55d"
 version = "1.6.3"
 
 [[deps.Pkg]]
-deps = ["Artifacts", "Dates", "Downloads", "FileWatching", "LibGit2", "Libdl", "Logging", "Markdown", "Printf", "Random", "SHA", "TOML", "Tar", "UUIDs", "p7zip_jll"]
+deps = ["Artifacts", "Dates", "Downloads", "FileWatching", "LibGit2", "Libdl", "Logging", "Markdown", "Printf", "REPL", "Random", "SHA", "Serialization", "TOML", "Tar", "UUIDs", "p7zip_jll"]
 uuid = "44cfe95a-1eb2-52ea-b672-e2afdf69b78f"
-version = "1.11.0"
-weakdeps = ["REPL"]
-
-    [deps.Pkg.extensions]
-    REPLExt = "REPL"
+version = "1.10.0"
 
 [[deps.Pluto]]
 deps = ["Base64", "Configurations", "Dates", "Downloads", "ExpressionExplorer", "FileWatching", "FuzzyCompletions", "HTTP", "HypertextLiteral", "InteractiveUtils", "Logging", "LoggingExtras", "MIMEs", "Malt", "Markdown", "MsgPack", "Pkg", "PlutoDependencyExplorer", "PrecompileSignatures", "PrecompileTools", "REPL", "RegistryInstances", "RelocatableFolders", "Scratch", "Sockets", "TOML", "Tables", "URIs", "UUIDs"]
@@ -263,17 +249,14 @@ version = "1.4.3"
 [[deps.Printf]]
 deps = ["Unicode"]
 uuid = "de0858da-6303-5e67-8744-51eddeeeb8d7"
-version = "1.11.0"
 
 [[deps.REPL]]
-deps = ["InteractiveUtils", "Markdown", "Sockets", "StyledStrings", "Unicode"]
+deps = ["InteractiveUtils", "Markdown", "Sockets", "Unicode"]
 uuid = "3fa0cd96-eef1-5676-8a61-b3b8758bbffb"
-version = "1.11.0"
 
 [[deps.Random]]
 deps = ["SHA"]
 uuid = "9a3f8284-a2c9-5f02-9a11-845980a1fd5c"
-version = "1.11.0"
 
 [[deps.RegistryInstances]]
 deps = ["LazilyInitializedFields", "Pkg", "TOML", "Tar"]
@@ -299,7 +282,6 @@ version = "1.2.1"
 
 [[deps.Serialization]]
 uuid = "9e88b42a-f829-5b0c-bbe9-9e923198166b"
-version = "1.11.0"
 
 [[deps.SimpleBufferStream]]
 git-tree-sha1 = "f305871d2f381d21527c770d4788c06c097c9bc1"
@@ -308,11 +290,6 @@ version = "1.2.0"
 
 [[deps.Sockets]]
 uuid = "6462fe0b-24de-5631-8697-dd941f90decc"
-version = "1.11.0"
-
-[[deps.StyledStrings]]
-uuid = "f489334b-da3d-4c2e-b8f0-e476e12c162b"
-version = "1.11.0"
 
 [[deps.TOML]]
 deps = ["Dates"]
@@ -339,7 +316,6 @@ version = "1.10.0"
 [[deps.Test]]
 deps = ["InteractiveUtils", "Logging", "Random", "Serialization"]
 uuid = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
-version = "1.11.0"
 
 [[deps.TranscodingStreams]]
 git-tree-sha1 = "0c45878dcfdcfa8480052b6ab162cdd138781742"
@@ -359,11 +335,9 @@ version = "1.5.1"
 [[deps.UUIDs]]
 deps = ["Random", "SHA"]
 uuid = "cf7118a7-6976-5b1a-9a39-7adc72f591a4"
-version = "1.11.0"
 
 [[deps.Unicode]]
 uuid = "4ec0a83e-493e-50e2-b9ac-8f72acf5a8f5"
-version = "1.11.0"
 
 [[deps.Zlib_jll]]
 deps = ["Libdl"]
@@ -373,7 +347,7 @@ version = "1.2.13+1"
 [[deps.nghttp2_jll]]
 deps = ["Artifacts", "Libdl"]
 uuid = "8e850ede-7688-5339-a07c-302acd2aaf8d"
-version = "1.59.0+0"
+version = "1.52.0+1"
 
 [[deps.p7zip_jll]]
 deps = ["Artifacts", "Libdl"]

--- a/Project.toml
+++ b/Project.toml
@@ -2,4 +2,4 @@
 Pluto = "c3e4b0f8-55cb-11ea-2926-15256bba5781"
 
 [compat]
-julia = "1.10"
+julia = "~1.10"

--- a/Project.toml
+++ b/Project.toml
@@ -2,4 +2,4 @@
 Pluto = "c3e4b0f8-55cb-11ea-2926-15256bba5781"
 
 [compat]
-julia = "1.11"
+julia = "1.10"

--- a/pluto_server_config.jl
+++ b/pluto_server_config.jl
@@ -1,0 +1,11 @@
+(
+    pkgimages="no",
+
+    require_secret_for_open_links=false,
+    require_secret_for_access=false,
+    warn_about_untrusted_code=false,
+
+    launch_browser=false,
+    dismiss_update_notification=true,
+    show_file_system=false,
+)

--- a/pluto_server_config.jl
+++ b/pluto_server_config.jl
@@ -1,5 +1,6 @@
 (
     pkgimages="no",
+    optimize=1,
 
     require_secret_for_open_links=false,
     require_secret_for_access=false,

--- a/plutoserver.py
+++ b/plutoserver.py
@@ -1,6 +1,9 @@
 def setup_plutoserver():
   return {
-    "command": ["julia", "--optimize=0", "-e", "import Pluto; Pluto.run(host=\"0.0.0.0\", port={port}, pkgimages=\"no\", workspace_use_distributed_stdlib=false, launch_browser=false, require_secret_for_open_links=false, require_secret_for_access=false, warn_about_untrusted_code=false, dismiss_update_notification=true, show_file_system=false)"],
+    "command": ["sh", "start_server.sh"],
+    "environment": {
+      "JSP_PORT": "{port}",
+    },
     "timeout": 60,
     "launcher_entry": {
         "title": "Pluto.jl",

--- a/postBuild
+++ b/postBuild
@@ -1,9 +1,9 @@
 #!/bin/bash
+set -ex
 
 echo "hello from postBuild"
 
-set -e
-
+# Optimziation:
 # Start Pluto, open new notebook, shut down notebook.
-# This should precompile the PlutoRunner boot environment.
+# This should precompile the PlutoRunner boot environment, so it launches faster when opening the new notebook on the live binder.
 julia --optimize=0 warmup_server.jl

--- a/postBuild
+++ b/postBuild
@@ -6,4 +6,4 @@ set -e
 
 # Start Pluto, open new notebook, shut down notebook.
 # This should precompile the PlutoRunner boot environment.
-julia --optimize=2 warmup_server.jl
+julia --optimize=0 warmup_server.jl

--- a/postBuild
+++ b/postBuild
@@ -1,0 +1,9 @@
+#!/bin/bash
+
+echo "hello from postBuild"
+
+set -e
+
+# Start Pluto, open new notebook, shut down notebook.
+# This should precompile the PlutoRunner boot environment.
+julia --optimize=2 warmup_server.jl

--- a/setup.py
+++ b/setup.py
@@ -12,8 +12,3 @@ setuptools.setup(
   },
   install_requires=['jupyter-server-proxy @ git+http://github.com/fonsp/jupyter-server-proxy@470e13ae0f7a8961202c76ea6bcbcfd27ed07e6a'],
 )
-
-# Start Pluto, open new notebook, shut down notebook.
-# This should precompile the PlutoRunner boot environment.
-import os
-os.system('julia --optimize=2 warmup_server.jl')

--- a/setup.py
+++ b/setup.py
@@ -10,5 +10,5 @@ setuptools.setup(
           'pluto = plutoserver:setup_plutoserver',
       ]
   },
-  install_requires=['jupyter-server-proxy @ git+http://github.com/fonsp/jupyter-server-proxy@3a58aa5005f942d0c208eab9a480f6ab171142ef'],
+  install_requires=['jupyter-server-proxy @ git+http://github.com/fonsp/jupyter-server-proxy@470e13ae0f7a8961202c76ea6bcbcfd27ed07e6a'],
 )

--- a/setup.py
+++ b/setup.py
@@ -16,4 +16,4 @@ setuptools.setup(
 # Start Pluto, open new notebook, shut down notebook.
 # This should precompile the PlutoRunner boot environment.
 import os
-os.system('julia --optimize=0 -e "@info("instantiate from setup.py"); import Pkg; Pkg.instantiate(); @info("import Pluto from setup.py"); import Pluto; @info("starting new notebook"); sesh = Pluto.ServerSession(options=Pluto.Configuration.from_flat_kwargs(; pkgimages="no")); nb = Pluto.SessionActions.new(sesh; run_async=false); @info("shutting down notebook"); Pluto.SessionActions.shutdown(sesh, nb; async=false); @info("setup.py done");"')
+os.system('julia --optimize=0 warmup_server.jl')

--- a/setup.py
+++ b/setup.py
@@ -16,4 +16,4 @@ setuptools.setup(
 # Start Pluto, open new notebook, shut down notebook.
 # This should precompile the PlutoRunner boot environment.
 import os
-os.system('julia --optimize=0 -e "import Pkg; Pkg.instantiate(); import Pluto; sesh = Pluto.ServerSession(); nb = Pluto.SessionActions.new(sesh; run_async=false); Pluto.SessionActions.shutdown(sesh, nb; async=false);"')
+os.system('julia --optimize=0 -e "@info("instantiate from setup.py"); import Pkg; Pkg.instantiate(); @info("import Pluto from setup.py"); import Pluto; @info("starting new notebook"); sesh = Pluto.ServerSession(options=Pluto.Configuration.from_flat_kwargs(; pkgimages="no")); nb = Pluto.SessionActions.new(sesh; run_async=false); @info("shutting down notebook"); Pluto.SessionActions.shutdown(sesh, nb; async=false); @info("setup.py done");"')

--- a/setup.py
+++ b/setup.py
@@ -12,3 +12,8 @@ setuptools.setup(
   },
   install_requires=['jupyter-server-proxy @ git+http://github.com/fonsp/jupyter-server-proxy@470e13ae0f7a8961202c76ea6bcbcfd27ed07e6a'],
 )
+
+# Start Pluto, open new notebook, shut down notebook.
+# This should precompile the PlutoRunner boot environment.
+import os
+os.system('julia --optimize=0 -e "import Pkg; Pkg.instantiate(); import Pluto; sesh = Pluto.ServerSession(); nb = Pluto.SessionActions.new(sesh; run_async=false); Pluto.SessionActions.shutdown(sesh, nb; async=false);"')

--- a/setup.py
+++ b/setup.py
@@ -16,4 +16,4 @@ setuptools.setup(
 # Start Pluto, open new notebook, shut down notebook.
 # This should precompile the PlutoRunner boot environment.
 import os
-os.system('julia --optimize=0 warmup_server.jl')
+os.system('julia --optimize=2 warmup_server.jl')

--- a/start_server.jl
+++ b/start_server.jl
@@ -1,0 +1,18 @@
+import Pluto
+
+@assert haskey(ENV, "JSP_PORT")
+
+Pluto.run(
+    host="0.0.0.0",
+    port=get(ENV, "JSP_PORT", nothing),
+
+    pkgimages="no",
+
+    require_secret_for_open_links=false,
+    require_secret_for_access=false,
+    warn_about_untrusted_code=false,
+
+    launch_browser=false,
+    dismiss_update_notification=true,
+    show_file_system=false,
+)

--- a/start_server.jl
+++ b/start_server.jl
@@ -2,17 +2,9 @@ import Pluto
 
 @assert haskey(ENV, "JSP_PORT")
 
-Pluto.run(
+Pluto.run(;
     host="0.0.0.0",
     port=parse(Int64, get(ENV, "JSP_PORT", nothing)),
 
-    pkgimages="no",
-
-    require_secret_for_open_links=false,
-    require_secret_for_access=false,
-    warn_about_untrusted_code=false,
-
-    launch_browser=false,
-    dismiss_update_notification=true,
-    show_file_system=false,
+    include("pluto_server_config.jl")...,
 )

--- a/start_server.jl
+++ b/start_server.jl
@@ -4,7 +4,7 @@ import Pluto
 
 Pluto.run(
     host="0.0.0.0",
-    port=get(ENV, "JSP_PORT", nothing),
+    port=parse(Int64, get(ENV, "JSP_PORT", nothing)),
 
     pkgimages="no",
 

--- a/start_server.sh
+++ b/start_server.sh
@@ -1,1 +1,1 @@
-julia --optimize=2 start_server.jl
+julia --optimize=0 start_server.jl

--- a/start_server.sh
+++ b/start_server.sh
@@ -1,1 +1,1 @@
-julia --optimize=0 start_server.jl 2&>1 | tee pluto_server.log
+julia --optimize=2 start_server.jl 2&>1 | tee pluto_server.log

--- a/start_server.sh
+++ b/start_server.sh
@@ -1,1 +1,1 @@
-julia --optimize=2 start_server.jl 2&>1 | tee pluto_server.log
+julia --optimize=2 start_server.jl

--- a/start_server.sh
+++ b/start_server.sh
@@ -1,0 +1,1 @@
+julia --optimize=0 start_server.jl 2&>1 | tee pluto_server.log

--- a/warmup_server.jl
+++ b/warmup_server.jl
@@ -6,15 +6,10 @@ Pkg.instantiate()
 import Pluto
 
 @info("starting new notebook from setup.py")
-sesh = Pluto.ServerSession(options=Pluto.Configuration.from_flat_kwargs(; 
-    pkgimages="no",
-))
+sesh = Pluto.ServerSession(options=Pluto.Configuration.from_flat_kwargs(; include("pluto_server_config.jl")...))
 nb = Pluto.SessionActions.new(sesh; run_async=false)
 
 
 @info("shutting down notebook from setup.py")
 Pluto.SessionActions.shutdown(sesh, nb; async=false)
 @info("setup.py done");
-
-
-error("DOES THIS EVEN WORK")

--- a/warmup_server.jl
+++ b/warmup_server.jl
@@ -1,0 +1,17 @@
+@info("instantiate from setup.py")
+import Pkg
+Pkg.instantiate()
+
+@info("import Pluto from setup.py")
+import Pluto
+
+@info("starting new notebook from setup.py")
+sesh = Pluto.ServerSession(options=Pluto.Configuration.from_flat_kwargs(; 
+    pkgimages="no",
+))
+nb = Pluto.SessionActions.new(sesh; run_async=false)
+
+
+@info("shutting down notebook from setup.py")
+Pluto.SessionActions.shutdown(sesh, nb; async=false)
+@info("setup.py done");

--- a/warmup_server.jl
+++ b/warmup_server.jl
@@ -15,3 +15,6 @@ nb = Pluto.SessionActions.new(sesh; run_async=false)
 @info("shutting down notebook from setup.py")
 Pluto.SessionActions.shutdown(sesh, nb; async=false)
 @info("setup.py done");
+
+
+error("DOES THIS EVEN WORK")


### PR DESCRIPTION
Fix https://github.com/fonsp/Pluto.jl/issues/3070

# Changes
- Downgrade from Julia 1.11 to Julia 1.10
- I updated the fork https://github.com/fonsp/jupyter-server-proxy based off jsp 4.4.1 (was 1.5.1). New fork: https://github.com/jupyterhub/jupyter-server-proxy/compare/main...fonsp:jupyter-server-proxy:okt-2024
- Create warmup file
- Create separate julia file for Pluto config (shared between warmup and server)
- Clean up command by creating `.jl` files
- Set optimize=1 for notebook processes