### PR TITLE
pkgimages = "existing"

### DIFF
--- a/pluto_server_config.jl
+++ b/pluto_server_config.jl
@@ -1,5 +1,5 @@
 (
-    pkgimages="no",
+    pkgimages="existing",
     optimize=1,
 
     require_secret_for_open_links=false,


### PR DESCRIPTION
In 1.11 we can instruct julia to use the existing pkgimages, but not make new ones.